### PR TITLE
Use product id as key

### DIFF
--- a/db/buildData.js
+++ b/db/buildData.js
@@ -25,20 +25,19 @@ const setupTraits = async () => {
 
 const setupGames = async (n) => {
   let chunks = Math.floor(n / CHUNK_SIZE) - 1;
-  let count = 0;
   let games = [];
   try {
     for (let i = 0; i <= chunks; i++) {
       const csvWriter = createCsvWriter({
         path: path.resolve(__dirname, 'data', `games${i}.csv`),
-        header: ['_key', 'product_id']
+        header: ['_key']
       });
       let chunk = [];
 
       for (let j = i * CHUNK_SIZE; j <= (i + 1) * CHUNK_SIZE - 1; j++) {
         let id = shortid.generate();
-        games.push([id, j]);
-        chunk.push([id, j]);
+        games.push([String(j)]);
+        chunk.push([String(j)]);
       }
 
       await csvWriter.writeRecords(chunk);

--- a/db/index.js
+++ b/db/index.js
@@ -16,13 +16,13 @@ const db = new Database({
 });
 
 //onst arango = arangojs();
-
-db.listDatabases().then((names) => {
-  if (!names.includes('traitsDB')) {
-    db.createDatabase('traitsDB');
+(async () => {
+  let databases = await db.listDatabases();
+  if (!databases.includes('traitsDB')) {
+    await db.createDatabase('traitsDB');
   }
-});
 
-db.useDatabase('traitsDB');
+  db.useDatabase('traitsDB');
+})();
 
 module.exports = db;

--- a/db/insertData.js
+++ b/db/insertData.js
@@ -26,6 +26,7 @@ const loadData = async () => {
     let data = fs.readFileSync(path.resolve(__dirname, 'data', files[j]), 'utf8');
     let collection = files[j].match(/(.+?)(?=\d|\.)/)[0];
     data = await neatCsv(data);
+    console.log('Inserting ' + files[j]);
     await insertData(data, collections[collection], trx);
   }
 
@@ -48,9 +49,9 @@ const setupCollections = async () => {
   let { games, traits, edges } = collections;
 
   try {
-    // if (games) await games.drop();
-    // if (traits) await traits.drop();
-    // if (edges) await edges.drop();
+    if (games) await games.drop();
+    if (traits) await traits.drop();
+    if (edges) await edges.drop();
 
     await games.create();
     await traits.create();
@@ -58,6 +59,7 @@ const setupCollections = async () => {
 
     return [games, traits, edges];
   } catch (err) {
+    console.log('Error setting up collections.');
     console.log(err.stack);
   }
 };


### PR DESCRIPTION
**Issue**
Products had a _key prop that was a rand string (a required prop) and a product_id prop. The _key is used by the edges and after using an edge query a second query was needed to get the product_id from the games collection.
**Solution**
Refactored the game schema to use the product_id as the key.

_key has to be a string, so anything using the product_id needs to convert it.